### PR TITLE
fixes to filtering

### DIFF
--- a/scn_js/src/components/FilterComponent.js
+++ b/scn_js/src/components/FilterComponent.js
@@ -34,7 +34,7 @@ const FilterComponent = ({token, fields, fieldsFull, filterLoaded, changeFilterF
         <h4>Below you can choose which part of the dataset you want to see in the Navigator</h4>
         <Form loading={!filterLoaded}>
         {fieldsFull.factor.map((key, index) => {
-            return  <Form.Group inline>
+            return  <Form.Group grouped>
                 <label>{key}</label>
                 {fieldsFull.factorLevels[key].map((value) => {
                   return <Form.Field

--- a/scn_js/src/utils/Plotting.js
+++ b/scn_js/src/utils/Plotting.js
@@ -352,6 +352,13 @@ function splitData(datas, traces, layout, anns, fields, splitField, axisXLayout,
         }
     } else {
         let uniqueVals = fields.factorLevels[splitField];
+
+        // Data check to only include factors that are present
+        let actualSplitVals = _.flatMap(datas, (data) => data.map(a => a[splitField]));
+        actualSplitVals = _.uniq(actualSplitVals);
+        uniqueVals = _.filter(uniqueVals, (a) => _.includes(actualSplitVals, a));
+
+
         let splits = uniqueVals.length;
 
         let columns = Math.ceil(Math.sqrt(splits));


### PR DESCRIPTION
long lists now displayed correctly, no more empty plots after split